### PR TITLE
Added Count of EventLog Entries

### DIFF
--- a/get-administrativeevent.ps1
+++ b/get-administrativeevent.ps1
@@ -162,10 +162,11 @@ happysysadm.com
                 $machineevents = $result | ? id -eq $id
 
                 $lastuniqueevents += $machineevents | sort timecreated -Descending | select -first 1
+				$lastuniqueevents | Add-Member -MemberType NoteProperty -Name "NumEvents" -Value ($machineevents | Measure).Count -Force
 
                 }
 
-            $AllResults += $lastuniqueevents
+            $AllResults += $lastuniqueevents | select MachineName, NumEvents, TimeCreated, ProviderName, LogName, Id, LevelDisplayName, Message
 
             }
     


### PR DESCRIPTION
Thought it would be useful to have a count of the number of EventLog entries that were returned even though the function will display only unique events.

Uses Add-Member to add another field to the $lastuniqueevents array which contains a count of $machineevents and then uses a select statement to reorder the fields before adding the $lastuniqueevents to $AllResults